### PR TITLE
Remove code and leave compatibility imports from perfmetrics.testing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,12 +3,11 @@
 =========
 
 
-0.0.3 (unreleased)
+1.0.0 (unreleased)
 ==================
 
-- Allow matcher values to be numbers or other matchers. See `issue 15
-  <https://github.com/NextThought/nti.fakestatsd/issues/15>`_.
-
+- This project has been merged into ``perfmetrics.testing``. There
+  will be no further development.
 
 0.0.2 (2018-10-26)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,13 @@
         :target: http://ntifakestatsd.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
+.. warning::
+
+   This project is deprecated and unmaintained. Its code has moved
+   into ``perfmetrics.testing``.
+
+   The following is for historical information only.
+
 nti.fakestatsd is a testing client for verifying StatsD metrics
 emitted by perfmetrics.
 
@@ -50,7 +57,7 @@ objects. For complete details see `~.FakeStatsDClient` and `~.Metric`.
   >>> test_client.packets
   ['request_c:1|c', 'active_sessions:320|g']
   >>> test_client.metrics
-  [Metric(name='request_c', value='1', kind='c', sampling_rate=None), Metric(name='active_sessions', value='320', kind='g', sampling_rate=None)]
+  [Observation(name='request_c', value='1', kind='c', sampling_rate=None), Observation(name='active_sessions', value='320', kind='g', sampling_rate=None)]
 
 For validating metrics we provide a set of hamcrest matchers for use
 in test assertions:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import codecs
 from setuptools import setup, find_packages
 
-version = '0.0.3.dev0'
+version = '1.0.0.dev0'
 
 entry_points = {
 }
@@ -33,7 +33,7 @@ setup(
         'Documentation': 'https://ntifakestatsd.readthedocs.io/',
     },
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
+        "Development Status :: 7 - Inactive",
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
@@ -52,7 +52,7 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=[
-        'perfmetrics',
+        'perfmetrics >= 3.0.0',
         'setuptools',
     ],
     extras_require={

--- a/src/nti/fakestatsd/__init__.py
+++ b/src/nti/fakestatsd/__init__.py
@@ -4,6 +4,7 @@
 from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
+
 __all__ = [
     'FakeStatsDClient',
     'Metric',
@@ -13,9 +14,10 @@ __all__ = [
     'METRIC_TIMER_KIND',
 ]
 
+from perfmetrics.testing import Observation as Metric
+from perfmetrics.testing import OBSERVATION_KIND_COUNTER as METRIC_COUNTER_KIND
+from perfmetrics.testing import OBSERVATION_KIND_GAUGE as METRIC_GAUGE_KIND
+from perfmetrics.testing import OBSERVATION_KIND_SET as METRIC_SET_KIND
+from perfmetrics.testing import OBSERVATION_KIND_TIMER as METRIC_TIMER_KIND
+
 from .client import FakeStatsDClient
-from .metric import Metric
-from .metric import METRIC_COUNTER_KIND
-from .metric import METRIC_GAUGE_KIND
-from .metric import METRIC_SET_KIND
-from .metric import METRIC_TIMER_KIND

--- a/src/nti/fakestatsd/client.py
+++ b/src/nti/fakestatsd/client.py
@@ -4,88 +4,15 @@
 from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
+__all__ = [
+    'FakeStatsDClient'
+]
 
-from perfmetrics.statsd import StatsdClient
 
-from .metric import Metric
+from perfmetrics.testing.client import FakeStatsDClient as _Base
 
-
-class FakeStatsDClient(StatsdClient):
-    """
-    A mock statsd client that tracks sent statsd metrics in memory
-    rather than pushing them over a socket. This class is a drop
-    in replacement for `perfmetrics.statsd.StatsdClient` that collects statsd
-    packets and `~.Metric` that are sent through the client.
-    """
-
-    def __init__(self, prefix=''):
-        """
-        Create a mock statsd client with the given prefix.
-        """
-        super(FakeStatsDClient, self).__init__(prefix=prefix)
-
-        # Monkey patch the socket to track things in memory instead
-        self._raw = _raw = []
-        self._metrics = _metrics = []
-
-        class DummySocket(object):
-            def sendto(self, data, addr):
-                # The client encoded to bytes
-                assert isinstance(data, bytes)
-                # We always want native strings here, that's what the
-                # user specified when calling the StatsdClient methods.
-                data = data.decode('utf-8') if bytes is not str else data
-                _raw.append((data, addr,))
-                for m in Metric.make_all(data):
-                    _metrics.append((m, addr,))
-
-        self.udp_sock.close()
-        self.udp_sock = DummySocket()
-
-    def clear(self):
-        """
-        Clears the statsd metrics that have been collected
-        """
-        del self._raw[:]
-        del self._metrics[:]
-
-    def __len__(self):
-        """
-        The number of metrics sent. This accounts for multi metric packets
-        that may be sent.
-        """
-        return len(self._metrics)
-
-    def __iter__(self):
-        """
-        Iterates the `Metrics <~.Metric>` provided to this statsd
-        client.
-        """
-        for metric, _ in self._metrics:
-            yield metric
-    iter_metrics = __iter__
-
-    def iter_raw(self):
-        """
-        Iterates the raw statsd packets provided to the statsd client.
-        """
-        for data, _ in self._raw:
-            yield data
+class FakeStatsDClient(_Base):
 
     @property
     def metrics(self):
-        """
-        A list of `~.Metric` objects collected by this client.
-
-        .. seealso:: `iter_metrics`
-        """
-        return [m for m in self]
-
-    @property
-    def packets(self):
-        """
-        A list of raw statsd packets collected by this client.
-
-        .. seealso:: `iter_raw`
-        """
-        return [p for p in self.iter_raw()]
+        return self.observations

--- a/src/nti/fakestatsd/matchers.py
+++ b/src/nti/fakestatsd/matchers.py
@@ -4,22 +4,6 @@
 from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
-from hamcrest.core.matcher import Matcher
-from hamcrest.core.base_matcher import BaseMatcher
-
-from hamcrest import all_of
-from hamcrest import instance_of
-from hamcrest import is_
-from hamcrest import has_properties
-from hamcrest import none
-
-from .metric import METRIC_GAUGE_KIND
-from .metric import METRIC_COUNTER_KIND
-from .metric import METRIC_TIMER_KIND
-from .metric import METRIC_SET_KIND
-
-from .metric import Metric
-
 __all__ = [
     'is_metric',
     'is_counter',
@@ -28,123 +12,8 @@ __all__ = [
     'is_timer',
 ]
 
-_marker = object()
-
-_metric_kind_display_name = {
-    'c': 'counter',
-    'g': 'gauge',
-    'ms': 'timer',
-    's': 'set'
-}
-
-class IsMetric(BaseMatcher):
-
-    def __init__(self, kwargs):
-        matchers = {}
-        for key, value in kwargs.items():
-            if value is None:
-                value = none()
-            elif key == 'sampling_rate':
-                # This one is special, it doesn't get
-                # to be a string, it's kept as a number.
-                value = is_(value)
-            elif not isinstance(value, Matcher):
-                value = str(value)
-            matchers[key] = value
-
-        self._matcher = all_of(
-            instance_of(Metric),
-            has_properties(**matchers)
-        )
-
-    def _matches(self, item):
-        return self._matcher.matches(item)
-
-    def describe_to(self, description):
-        self._matcher.describe_to(description)
-
-    def describe_mismatch(self, item, mismatch_description):
-        mismatch_description.append_text('was ').append_text(repr(item))
-
-def _is_metric(args, kwargs):
-    for arg_ix, name in enumerate((
-            'kind',
-            'name',
-            'value',
-            'sampling_rate'
-    )):
-        if name in kwargs or len(args) <= arg_ix:
-            continue
-        kwargs[name] = args[arg_ix]
-
-    return IsMetric(kwargs)
-
-
-def is_metric(*args, **kwargs):
-    """
-    is_metric(*, kind, name, value, sampling_rate) -> matcher
-
-    A hamcrest matcher that validates the specific parts of a `~.Metric`.
-
-    :keyword str kind: A hamcrest matcher or string that matches the kind for this metric
-    :keyword str name: A hamcrest matcher or string that matches the name for this metric
-    :keyword value: A hamcrest matcher or string that matches the value for this metric
-    :keyword sampling_rate: A hamcrest matcher or
-        number that matches the sampling rate this metric was collected with
-    """
-    return _is_metric(args, kwargs)
-
-
-def is_counter(*args, **kwargs):
-    """
-    is_counter(*, name, value, sampling_rate) -> matcher
-
-    A hamcrest matcher validating the parts of a `~.Metric` of kind
-    `~.METRIC_COUNTER_KIND`
-
-    .. seealso:: `is_metric`
-    """
-    kwargs['kind'] = METRIC_COUNTER_KIND
-    args = (None,) + args
-    return _is_metric(args, kwargs)
-
-
-def is_gauge(*args, **kwargs):
-    """
-    is_gauge(*, name, value, sampling_rate) -> matcher
-
-    A hamcrest matcher validating the parts of a `~.Metric` of kind
-    `~.METRIC_GAUGE_KIND`
-
-    .. seealso:: `is_metric`
-    """
-    kwargs['kind'] = METRIC_GAUGE_KIND
-    args = (None,) + args
-    return _is_metric(args, kwargs)
-
-
-def is_timer(*args, **kwargs):
-    """
-    is_timer(*, name, value, sampling_rate) -> matcher
-
-    A hamcrest matcher validating the parts of a `~.Metric` of kind
-    `~.METRIC_TIMER_KIND`
-
-    .. seealso:: `is_metric`
-    """
-    kwargs['kind'] = METRIC_TIMER_KIND
-    args = (None,) + args
-    return _is_metric(args, kwargs)
-
-def is_set(*args, **kwargs):
-    """
-    is_set(*, name, value, sampling_rate) -> matcher
-
-    A hamcrest matcher validating the parts of a `~.Metric` of kind
-    `~.METRIC_SET_KIND`
-
-    .. seealso:: `is_metric`
-    """
-    kwargs['kind'] = METRIC_SET_KIND
-    args = (None,) + args
-    return _is_metric(args, kwargs)
+from perfmetrics.testing.matchers import is_observation as is_metric
+from perfmetrics.testing.matchers import is_counter
+from perfmetrics.testing.matchers import is_set
+from perfmetrics.testing.matchers import is_gauge
+from perfmetrics.testing.matchers import is_timer

--- a/src/nti/fakestatsd/metric.py
+++ b/src/nti/fakestatsd/metric.py
@@ -4,121 +4,16 @@
 from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
-#: The statsd metric kind for Gauges
-METRIC_GAUGE_KIND = 'g'
+__all__ = [
+    'Metric',
+    'METRIC_COUNTER_KIND',
+    'METRIC_GAUGE_KIND',
+    'METRIC_SET_KIND',
+    'METRIC_TIMER_KIND',
+]
 
-#: The statsd metric kind for Counters
-METRIC_COUNTER_KIND = 'c'
-
-#: The statsd metric kind for Sets
-METRIC_SET_KIND = 's'
-
-#: The statsd metric kind for Timers
-METRIC_TIMER_KIND = 'ms'
-
-
-def _parse_sampling_data(data):
-    """
-    Parses sampling rate from the provided packet part *data*.
-
-    Raises a `ValueError` if the packet part is invalid sampling data
-    """
-    if not data.startswith('@'):
-        raise ValueError('Expected "@" in sampling data. %s' % data)
-    return float(data[1:])
-
-
-def _as_metric(metric_data):
-    """
-    Parses a single metric packet, *metric_data*, in to a `Metric`.
-
-    Metrics take the form of <name>:<value>|<type>(|@<sampling_rate>)
-
-    A `ValueError` is raised for invalid data
-    """
-
-    sampling = None
-    name = None
-    value = None
-    kind = None
-    parts = metric_data.split('|')
-    if len(parts) < 2 or len(parts) > 3:
-        raise ValueError('Unexpected metric data %s. Wrong number of parts' % metric_data)
-
-    if len(parts) == 3:
-        sampling_data = parts.pop(-1)
-        sampling = _parse_sampling_data(sampling_data)
-
-    kind = parts[1]
-    name, value = parts[0].split(':')
-
-    return Metric(name, value, kind, sampling_rate=sampling)
-
-
-def _as_metrics(data):
-    """
-    Parses the statsd *data* packet to a _list_ of metrics.
-
-    .. seealso:: https://github.com/etsy/statsd/blob/master/docs/metric_types.md
-    """
-    metrics = []
-
-    # Multi metric packets are seperated by newlines
-    for metric_data in data.split('\n'):
-        metrics.append(_as_metric(metric_data))
-    return metrics
-
-
-class Metric(object):
-    """
-    The representation of a single statsd metric.
-    """
-
-    #: The metric name
-    name = None
-
-    #: The value provided for the metric
-    value = None
-
-    #: The statsd code for the type of metric. e.g. one of the ``METRIC_*_KIND`` constants
-    kind = None
-
-    #: The rate with which this event has been sampled from (optional)
-    sampling_rate = None
-
-    def __init__(self, name, value, kind, sampling_rate=None):
-        self.name = name
-        self.value = value
-        self.sampling_rate = sampling_rate
-        self.kind = kind
-
-    @classmethod
-    def make(cls, packet):
-        """
-        Creates a metric from the provided statsd *packet*.
-
-        :raises ValueError: if *packet* is a multi metric packet or
-                 otherwise invalid.
-        """
-        metrics = cls.make_all(packet)
-        if len(metrics) != 1:
-            raise ValueError('Must supply a single metric packet. %s supplied' % packet)
-        return metrics[0]
-
-    @classmethod
-    def make_all(cls, packet):
-        """
-        Makes a list of metrics from the provided statsd *packet*.
-
-        Like `make` but supports multi metric packets
-        """
-        return _as_metrics(packet)
-
-    def __str__(self):
-        sampling_string = '|@%g' % self.sampling_rate if self.sampling_rate is not None else ''
-        return '%s:%s|%s%s' % (self.name, self.value, self.kind, sampling_string)
-
-    def __repr__(self):
-        return "Metric(name=%r, value=%r, kind=%r, sampling_rate=%r)" % (
-            self.name, self.value, self.kind, self.sampling_rate
-        )
+from perfmetrics.testing.observation import Observation as Metric
+from perfmetrics.testing import OBSERVATION_KIND_COUNTER as METRIC_COUNTER_KIND
+from perfmetrics.testing import OBSERVATION_KIND_GAUGE as METRIC_GAUGE_KIND
+from perfmetrics.testing import OBSERVATION_KIND_SET as METRIC_SET_KIND
+from perfmetrics.testing import OBSERVATION_KIND_TIMER as METRIC_TIMER_KIND

--- a/src/nti/fakestatsd/tests/test_matchers.py
+++ b/src/nti/fakestatsd/tests/test_matchers.py
@@ -76,7 +76,7 @@ class TestIsMetric(unittest.TestCase):
             desc,
             all_of(
                 contains_string(
-                    "(an instance of Metric and "),
+                    "(an instance of Observation and "),
                 contains_string(
                     "an object with a property 'kind' matching 'c'"),
                 contains_string(


### PR DESCRIPTION
Leaves all the tests in place to be sure backwards compatibility is still there.

Refs #18